### PR TITLE
correct python package name robotframework-qconnect-base for install_requires

### DIFF
--- a/config/repository_config.json
+++ b/config/repository_config.json
@@ -13,8 +13,7 @@
    "DEVELOPMENTSTATUS" : "Development Status :: 4 - Beta",
    "INTENDEDAUDIENCE" : "Intended Audience :: Developers",
    "TOPIC" : "Topic :: Software Development",
-   "INSTALLREQUIRES" : ["robotframework","QConnectBase","Appium-Python-Client","selenium"],
+   "INSTALLREQUIRES" : ["robotframework","robotframework-qconnect-base","Appium-Python-Client","selenium"],
    "PACKAGEDATA" : ["*.resource","*.pdf"],
    "PACKAGEDOC" : "./packagedoc"
 }
-


### PR DESCRIPTION
This Pr fix issue https://github.com/test-fullautomation/robotframework-qconnect-base/issues/224 when checking with pip